### PR TITLE
fix/netifly-build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
-command = "npm run build"
-publish = "frontend/build"
+  base = "/"
+  command = "npm run build --prefix frontend"
+  publish = "frontend/build"


### PR DESCRIPTION
This configuration tells Netlify to run the build command (npm run build) from the frontend directory (--prefix frontend) and publish the build output from the frontend/build directory